### PR TITLE
Handle use effect re-renders for exploration tool

### DIFF
--- a/src/hubbleds/components/intro_slideshow/intro_slideshow.py
+++ b/src/hubbleds/components/intro_slideshow/intro_slideshow.py
@@ -23,51 +23,59 @@ _titles = [
     "Vesto Slipher and Spectral Data"
 ]
 
+
 def carousel_title(step, titles):
-    with rv.Toolbar(color="warning", dense=True,):
-        with rv.ToolbarTitle( ):
+    with rv.Toolbar(color="warning", dense=True, ):
+        with rv.ToolbarTitle():
             solara.Text(titles[step], classes=["toolbar-title"])
 
 
-@dataclasses.dataclass
-class ComponentState:
-    coordinates: Reactive[SkyCoord] = dataclasses.field(
-        default=Reactive(SkyCoord(0 * u.deg, 0 * u.deg, frame="icrs"))
-    )
+@solara.component
+def ExplorationToolComponent(coordinates):
+    tool = ExplorationTool.element()
 
-component_state = ComponentState()
+    def go_to_coordinates():
+        print("go_to_coordinates")
+        print(coordinates.value)
+        if coordinates.value:
+            tool_widget = solara.get_widget(tool)
+            print(tool_widget)
+            print(tool_widget.widget)
+            print(tool_widget.widget.center_on_coordinates)
+            tool_widget.go_to_coordinates(coordinates.value)
 
-def update_coordinates(coords):
-    print("update_coordinates")
-    print(coords)
-    component_state.coordinates.set(coords)
+    solara.use_effect(go_to_coordinates, [coordinates.value])
 
-def IntroSlideshow():
+    return tool
+
+
+@solara.component
+def IntroSlideshow(coordinates):
     step, on_step = solara.use_state(0)
-    coordinates = solara.use_reactive(None)
+
+    # coordinates = solara.use_reactive(None)
 
     @solara.lab.computed
     def index():
         return step + 1
 
     with rv.Carousel(
-        v_model=step,
-        on_v_model=on_step,
-        value=step + 1,
-        hide_delimiters=True,
-        hide_delimiter_background=True,
-        show_arrows=False,
-        height="100%",
+            v_model=step,
+            on_v_model=on_step,
+            value=step + 1,
+            hide_delimiters=True,
+            hide_delimiter_background=True,
+            show_arrows=False,
+            height="100%",
     ) as carousel:
-
-        # Just a dummy thing for testing 
-        solara.Text(str(component_state.coordinates.value))
+        # Just a dummy thing for testing
+        solara.Text(str(coordinates.value))
 
         # Slide 0
         with rv.CarouselItem():
             carousel_title(step, _titles)
 
-            with solara.ColumnsResponsive(12, large=[5,7]):
+            with solara.ColumnsResponsive(12, large=[5, 7]):
                 with solara.Column(align="center"):
                     solara.HTML(
                         unsafe_innerHTML=
@@ -78,8 +86,8 @@ def IntroSlideshow():
                         <p>
                         In this <b>Cosmic Data Story</b>, you will use authentic astronomical data to investigate the mysteries of our Universe. In particular, you will be answering these questions:
                         </p>
-                        """  ,
-                        classes = ["padded-text"],                 
+                        """,
+                        classes=["padded-text"],
                     )
 
                     with solara.Card(style="background-color: blue"):
@@ -102,10 +110,10 @@ def IntroSlideshow():
 
                 with solara.Column(align="center"):
                     rv.Img(
-                        src = image_location + "MilkyWayOverMountainsNASASTScILevay.jpg",
-                        max_height = 550,
-                        contain = True,
-                        alt = "Colorful image of our Milky Way galaxy in the sky over a dark silhouette of mountains on the horizon.",
+                        src=image_location + "MilkyWayOverMountainsNASASTScILevay.jpg",
+                        max_height=550,
+                        contain=True,
+                        alt="Colorful image of our Milky Way galaxy in the sky over a dark silhouette of mountains on the horizon.",
                     )
                     solara.Text(
                         "Our Milky Way galaxy over a mountain range. (Credit: NASA and STScI)",
@@ -117,7 +125,7 @@ def IntroSlideshow():
             carousel_title(step, _titles)
 
             with solara.Row():
-                with solara.ColumnsResponsive(12, large=[7,5]):
+                with solara.ColumnsResponsive(12, large=[7, 5]):
                     with solara.Column(align="center"):
                         solara.HTML(
                             unsafe_innerHTML=
@@ -132,7 +140,7 @@ def IntroSlideshow():
                                     Let's get started.
                                 </p>
                             """,
-                        classes = ["padded-text"],                       
+                            classes=["padded-text"],
                         )
 
                     with solara.Column(align="center"):
@@ -142,7 +150,7 @@ def IntroSlideshow():
                                     unsafe_innerHTML=
                                     f"""
                                     <img
-                                        src = '{ image_location }HST-SM4.jpeg'
+                                        src = '{image_location}HST-SM4.jpeg'
                                         style = 'max-height: 250px;'
                                         alt = 'The Hubble Space Telescope against a dark background'
                                     />
@@ -153,7 +161,7 @@ def IntroSlideshow():
                                     unsafe_innerHTML=
                                     f"""
                                     <img
-                                        src = '{ image_location }EdwinHubble.jpg'
+                                        src = '{image_location}EdwinHubble.jpg'
                                         style = 'max-height: 250px;'
                                         alt = 'Astronomer Edwin Hubble holding an image of the Andromeda Galaxy'
                                     />
@@ -163,14 +171,14 @@ def IntroSlideshow():
                             "The Hubble Space Telescope and Edwin Hubble, the astronomer it was named for. Hubble holds an image of the Andromeda Galaxy, for which the earliest recorded observation was made in 964 AD by Iranian scholar al-Sufi.",
                             classes=["caption", ],
                             style="text-align: center; max-width: 80%",
-                        )        
+                        )
 
-        # Slide 2
+                        # Slide 2
         with rv.CarouselItem():
             carousel_title(step, _titles)
 
             with solara.Row():
-                with solara.ColumnsResponsive(12, large=[5,7]):
+                with solara.ColumnsResponsive(12, large=[5, 7]):
                     with solara.Column(align="center"):
                         solara.HTML(
                             unsafe_innerHTML=
@@ -179,7 +187,7 @@ def IntroSlideshow():
                             Imagine that you are an astronomer living in the <b>early 1900s</b>. You and your colleagues around the world, including Albert Einstein, would agree that the <b>universe is unchanging</b> and <b>everlasting.</b> In other words, you expect that the universe always has been and will be the way it is the way you see it now. This picture of an unchanging universe had rarely been questioned throughout human history, thanks in large part to <b>Aristotle</b>, who embraced perfection and permanence. 
                             </p>
                             """,
-                            classes = ["padded-text"],    
+                            classes=["padded-text"],
                         )
 
                     with solara.Column(align="center"):
@@ -189,7 +197,7 @@ def IntroSlideshow():
                                     unsafe_innerHTML=
                                     f"""
                                     <img
-                                        src = "{ image_location }Astronomer_Edward_Charles_Pickering's_Harvard_computers.jpg"
+                                        src = "{image_location}Astronomer_Edward_Charles_Pickering's_Harvard_computers.jpg"
                                         style = 'max-height: 300px;'
                                         alt = 'Eight women astronomers, wearing late 1800s clothing and hairstyles, are sitting or standing in a room. Some are observing astronomical images with magnifying glasses. Some are writing in notebooks.'
                                     />
@@ -199,7 +207,7 @@ def IntroSlideshow():
                                     "Women astronomers at Harvard College Observatory in 1892, including Henrietta Leavitt (third from left), Williamina Fleming (standing), and Annie Jump Cannon (far right).",
                                     classes=["caption", ],
                                     style="text-align: center; max-width: 80%",
-                                )    
+                                )
                             with solara.Column(align="center"):
                                 with solara.Columns(6):
                                     with solara.Column(align="end"):
@@ -207,30 +215,30 @@ def IntroSlideshow():
                                             unsafe_innerHTML=
                                             f"""
                                             <img
-                                                src = '{ image_location }Einstein_1921_by_F_Schmutzer_-_restorationCropped.png'
+                                                src = '{image_location}Einstein_1921_by_F_Schmutzer_-_restorationCropped.png'
                                                 style = 'max-height: 150px;'
                                                 alt = 'Portrait of Albert Einstein'
                                             />
                                             """
-                                        )                                        
+                                        )
                                     with solara.Column(align="start"):
                                         solara.HTML(
                                             unsafe_innerHTML=
                                             f"""
                                             <img
-                                                src = '{ image_location }AristotleSchoolOfAthensCutoutZoom.png'
+                                                src = '{image_location}AristotleSchoolOfAthensCutoutZoom.png'
                                                 style = 'max-height: 150px;'
                                                 alt = 'Cutout showing a small portion of a much larger, colorful paiting by Raphael depicting Aristotle wearing a blue robe.'
                                             />
                                             """
-                                        )                                      
+                                        )
                                 solara.Text(
                                     "Left: Albert Einstein in 1921. Right: Aristotle, depicted in “The School of Athens,” painted by Raphael for the walls of the Vatican between 1509 and 1511. Both believed in an unchanging universe.",
                                     classes=["caption", ],
                                     style="text-align: center; max-width: 80%",
-                                )        
-        
-        # Slide 3
+                                )
+
+                                # Slide 3
         with rv.CarouselItem():
             carousel_title(step, _titles)
 
@@ -248,7 +256,7 @@ def IntroSlideshow():
                         You can explore this view and see what is in the night sky, as astronomers have been doing for centuries. <b>Pan</b> (click and drag) and <b>zoom</b> (scroll in and out) to see parts of the sky beyond this view.
                     </p>
                     """,
-                    classes = ["padded-text"],    
+                    classes=["padded-text"],
                 )
 
                 with solara.Columns([8, 4]):
@@ -258,9 +266,9 @@ def IntroSlideshow():
                             "Interactive view provided by WorldWide Telescope",
                             classes=["caption"],
                             style="text-align: center",
-                        )       
+                        )
                     with solara.Column(align="center", gap="20px"):
-                        with solara.ColumnsResponsive(12, large=[4,8]):
+                        with solara.ColumnsResponsive(12, large=[4, 8]):
                             with solara.Column():
                                 rv.Chip(label=True, outlined=True, children=["Pan"])
                             with solara.Column():
@@ -271,7 +279,7 @@ def IntroSlideshow():
                                     (or use <b>I-J-K-L</b> keys)
                                     """
                                 )
-                        with solara.ColumnsResponsive(12, large=[4,8]):
+                        with solara.ColumnsResponsive(12, large=[4, 8]):
                             with solara.Column():
                                 rv.Chip(label=True, outlined=True, children=["Zoom"])
                             with solara.Column():
@@ -287,21 +295,9 @@ def IntroSlideshow():
         with rv.CarouselItem():
             carousel_title(step, _titles)
 
-            def go_to_coordinates():
-                print("go_to_coordinates")
-                print(component_state.coordinates.value)
-                if component_state.coordinates.value:
-                    tool_widget = solara.get_widget(tool)
-                    print(tool_widget)
-                    print(tool_widget.widget)
-                    print(tool_widget.widget.center_on_coordinates)
-                    tool_widget.go_to_coordinates(component_state.coordinates.value)
-            
-            solara.use_effect(go_to_coordinates, [component_state.coordinates.value])
-    
             def set_coords_m1():
                 print("Button clicked")
-                update_coordinates(SkyCoord(83.633 * u.deg, 22.014 * u.deg, frame="icrs"))
+                coordinates.set(SkyCoord(83.633 * u.deg, 22.014 * u.deg, frame="icrs"))
                 print(coordinates.value)
 
             with solara.Column():
@@ -315,25 +311,22 @@ def IntroSlideshow():
                         Click on the buttons to the right to <b>view some Messier Objects</b>. (Fun fact: “nebula” means “cloud” or “fog” in Latin.)
                     </p>
                     """,
-                    classes = ["padded-text"],    
+                    classes=["padded-text"],
                 )
 
                 with solara.Columns([2, 1]):
                     with solara.Column():
-                        tool = ExplorationTool.element()
+                        ExplorationToolComponent(coordinates)
 
                         solara.Text(
                             "Interactive view provided by WorldWide Telescope",
                             classes=["caption"],
                             style="text-align: center",
-                        ) 
-                    
+                        )
+
                     with solara.Column():
-                        with solara.ColumnsResponsive(12, large=[6,6]):
+                        with solara.ColumnsResponsive(12, large=[6, 6]):
                             with solara.Column():
-
-
-
                                 solara.Button(
                                     label="M1",
                                     color="warning",
@@ -360,9 +353,9 @@ def IntroSlideshow():
                                 solara.Button(
                                     label="M82",
                                     color="warning",
-                                )                                
+                                )
 
-        # Slide 5
+                                # Slide 5
         with rv.CarouselItem():
             carousel_title(step, _titles)
 
@@ -377,7 +370,7 @@ def IntroSlideshow():
                         While you view these spiral nebulae, ponder what you would need to know to determine if they are within the Milky Way or beyond it. (Don't worry if you don't know. You will learn in this Data Story.) 
                     </p>
                     """,
-                    classes = ["padded-text"],                        
+                    classes=["padded-text"],
                 )
 
                 with solara.Columns([2, 1]):
@@ -387,10 +380,10 @@ def IntroSlideshow():
                             "Interactive view provided by WorldWide Telescope",
                             classes=["caption"],
                             style="text-align: center",
-                        )  
-                    
+                        )
+
                     with solara.Column():
-                        with solara.ColumnsResponsive(12, large=[6,6]):
+                        with solara.ColumnsResponsive(12, large=[6, 6]):
                             with solara.Column():
                                 solara.Button(
                                     label="M1",
@@ -409,20 +402,20 @@ def IntroSlideshow():
                                 solara.Button(
                                     label="M13",
                                     color="warning",
-                                    disabled=True                                    
+                                    disabled=True
                                 )
                                 solara.Button(
                                     label="M42",
                                     color="warning",
-                                    disabled=True                                    
+                                    disabled=True
                                 )
                                 solara.Button(
                                     label="M82",
                                     color="warning",
-                                    disabled=True                                    ,
-                                )        
+                                    disabled=True,
+                                )
 
-        # Slide 6
+                                # Slide 6
         with rv.CarouselItem():
             carousel_title(step, _titles)
 
@@ -434,51 +427,49 @@ def IntroSlideshow():
                     Between 1907&#8211;1921, Harvard astronomer <b>Henrietta Leavitt</b> observed Cepheid variable stars in a nebula called the Small Magellanic Cloud (SMC). By analyzing changes in the Cepheid stars’ brightness over time, she discovered that <b>fainter Cepheids vary more slowly than brighter ones</b>, as shown in her graph below. This important discovery made it possible to determine distances to spiral nebulae and finally resolve the Shapley-Curtis Great Debate: it turned out that spiral nebulae are far beyond the Milky Way and constitute <b>individual galaxies</b> in their own right.
                     </p>
                     """,
-                    classes = ["padded-text"],    
+                    classes=["padded-text"],
                 )
 
             with solara.Columns([2, 1]):
-                with solara.Column(align="center"):                
+                with solara.Column(align="center"):
                     rv.Img(
-                        src = image_location + "Leavitt_at_work.jpg",
-                        max_height = 350,
-                        contain = True,  
-                        alt = "Photograph of Henrietta Leavitt writing in a notebook. Several other notes are open neatly around her desk.",
+                        src=image_location + "Leavitt_at_work.jpg",
+                        max_height=350,
+                        contain=True,
+                        alt="Photograph of Henrietta Leavitt writing in a notebook. Several other notes are open neatly around her desk.",
                     )
                     solara.Text(
                         "Astronomer Henrietta Swan Leavitt",
                         classes=["caption", ],
                         style="text-align: center; max-width: 100%",
-                    )     
-                
+                    )
+
                 with solara.Column(align="center"):
                     rv.Img(
-                        src = image_location + "Leavitt_Plate.png",
-                        max_height = 200,
-                        contain = True,
-                        alt = "Photographic glass plate of the Small Magellenic Cloud. Handwritten markings are scattered around the plate, noting objects of interest.",  
+                        src=image_location + "Leavitt_Plate.png",
+                        max_height=200,
+                        contain=True,
+                        alt="Photographic glass plate of the Small Magellenic Cloud. Handwritten markings are scattered around the plate, noting objects of interest.",
                     )
                     solara.Text(
                         "Glass plate showing Cepheid variable stars in Small Magellanic Cloud studied by Leavitt",
                         classes=["caption", ],
                         style="text-align: center; max-width: 100%",
-                    ) 
+                    )
 
                     rv.Img(
-                        src = image_location + "HSLeavittHSCr13Fig2_1912.jpeg",
-                        max_height = 200,
-                        contain = True,  
-                        alt = "A graph depicting stellar magnitude on the y-axis and period in days on the x-axis. Two plots are shown that go from the bottom left to the upper right of the chart.",
+                        src=image_location + "HSLeavittHSCr13Fig2_1912.jpeg",
+                        max_height=200,
+                        contain=True,
+                        alt="A graph depicting stellar magnitude on the y-axis and period in days on the x-axis. Two plots are shown that go from the bottom left to the upper right of the chart.",
                     )
                     solara.Text(
                         "Graph from Leavitt's 1912 paper showing the relationship between period and brightness of Cepheid variables.",
                         classes=["caption", ],
                         style="text-align: center; max-width: 100%",
-                    ) 
+                    )
 
-
-
-        # Slide 7
+                    # Slide 7
         with rv.CarouselItem():
             carousel_title(step, _titles)
 
@@ -497,22 +488,21 @@ def IntroSlideshow():
                         It’s time for you to collect some of your own data, form conclusions, and compare your conclusions to what Vesto Slipher found.
                         </p>
                         """,
-                        classes = ["padded-text"],                            
+                        classes=["padded-text"],
                     )
 
                 with solara.Column(align="center"):
                     rv.Img(
-                        src = image_location + "V.M.Slipher.gif",
-                        max_height = 400,
-                        contain = True,  
-                        alt = "Portrait of Vesto Slipher",
+                        src=image_location + "V.M.Slipher.gif",
+                        max_height=400,
+                        contain=True,
+                        alt="Portrait of Vesto Slipher",
                     )
                     solara.Text(
                         "Astronomer Vesto Slipher",
                         classes=["caption", ],
                         style="text-align: center; max-width: 100%",
-                    ) 
-
+                    )
 
     rv.Divider(class_="mt-4")
 

--- a/src/hubbleds/pages/__init__.py
+++ b/src/hubbleds/pages/__init__.py
@@ -1,8 +1,23 @@
 import solara
 from ..components import IntroSlideshow
+import dataclasses
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from solara import Reactive
 
 from cosmicds.layout import Layout
 
+
+@dataclasses.dataclass
+class ComponentState:
+    coordinates: Reactive[SkyCoord] = dataclasses.field(
+        default=Reactive(SkyCoord(0 * u.deg, 0 * u.deg, frame="icrs"))
+    )
+
+
+component_state = ComponentState()
+
+
 @solara.component
 def Page():
-    IntroSlideshow()    
+    IntroSlideshow(component_state.coordinates)


### PR DESCRIPTION
@Carifio24 There were a few things that were at play, so I ended up just making a copy of your branch so I could highlight them more easily. Feel free to copy over what you want and close this, or just pull it in (my formatter got aggressive when I pushed this up, so I there's minor pep-related changes that got included which might be annoying).

1. I would suggest we try and keep `component_state` stuff in the top-level `Page` file, just to ensure page-level state stays with the page it goes with and doesn't get buried in separate individual components. You'll notice I moved the `ComponentState` back to the `__init__.py` file and just passed in the relevant piece to the `IntroSlideshow` component.
2. The `IntroSlideshow` component should also be a `solara.component` itself, since we use it as such (have `use_reactive` variables, etc.), and it's also important for certain solara context-sensitive issues.
3. I'm not actually super sure why the `use_effect` wasn't working, but it seems that just wrapping it in its own solara component (`ExplorationToolComponent` at the top of the `IntroSlideshow` file) seemed to solve the issue. I'll try and ping Maarten about why this might be, but for now, at least we know some possible solutions if we come across this issue.